### PR TITLE
Update runtime to 6.7, LLVM to 18

### DIFF
--- a/com.librumreader.librum.yaml
+++ b/com.librumreader.librum.yaml
@@ -1,10 +1,13 @@
 app-id: com.librumreader.librum
 runtime: org.kde.Platform
-runtime-version: '6.5'
+runtime-version: '6.7'
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.llvm16
+  - org.freedesktop.Sdk.Extension.llvm18
 sdk: org.kde.Sdk
 command: librum
+build-options:
+  append-path: /usr/lib/sdk/llvm18/bin
+  prepend-ld-library-path: /usr/lib/sdk/llvm18/lib
 finish-args:
   - --share=ipc
   - --share=network
@@ -25,6 +28,7 @@ modules:
     sources:
         - type: git
           url: https://github.com/Librum-Reader/Librum.git
+          tag: v.0.12.2
           commit: dab488883f2e61ece757fe03107068b132877a66
     post-install:
       - install -Dm644 librum.desktop -t /app/share/applications

--- a/python3-libclang.yaml
+++ b/python3-libclang.yaml
@@ -3,10 +3,7 @@ buildsystem: simple
 build-commands:
   - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
     --prefix=${FLATPAK_DEST} "libclang" --no-build-isolation
-  - mkdir -p $FLATPAK_DEST/lib
-  - cp $(readlink -f /usr/lib/sdk/llvm16/lib/libclang.so) $FLATPAK_DEST/lib/libclang.so
-
 sources:
   - type: file
-    url: https://files.pythonhosted.org/packages/c2/01/ec65dffc8c94bd8cafd359a76992f3212a239a80ead05522995c105432b8/libclang-16.0.6.tar.gz
-    sha256: 4acdde39dfe410c877b4ccc0d4b57eb952100e4ee26bbdf6cfdb88e2033a7d31
+    url: https://files.pythonhosted.org/packages/6e/5c/ca35e19a4f142adffa27e3d652196b7362fa612243e2b916845d801454fc/libclang-18.1.1.tar.gz
+    sha256: a1214966d08d73d971287fc3ead8dfaf82eb07fb197680d8b3859dbbbbf78250


### PR DESCRIPTION
Building with KDE 6.8 also works, but then Librum crashes when starting:

```
Librum: qrc:/main.qml:86:27: Type MAlertBox unavailable
Librum: qrc:/modules/CustomComponents/MAlertBox.qml:72:13: IconImage is not a type
```

I guess this error is somewhat related to 6.8, but was unable to find anything related to it.